### PR TITLE
adding AC_CONFIG_MACRO_DIR([m4]) to configure.in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,8 @@ SUBDIRS = include
 
 DISTCHECK_CONFIGURE_FLAGS = --disable-silent-rules
 
-INCLUDES =                             \
+ACLOCAL_AMFLAGS= -I m4
+AM_CPPFLAGS =                          \
 	-DYYDEBUG=1                    \
 	-DYYERROR_VERBOSE=1            \
 	-I$(top_builddir)/include      \

--- a/configure.in
+++ b/configure.in
@@ -46,6 +46,7 @@ AC_ARG_ENABLE(compile-warnings,
 dnl Make sure that $ACLOCAL_FLAGS is passed to subsequent aclocal runs.
 ACLOCAL_AMFLAGS="\${ACLOCAL_FLAGS}"
 AC_SUBST([ACLOCAL_AMFLAGS])
+AC_CONFIG_MACRO_DIR([m4])
 
 AC_ISC_POSIX
 


### PR DESCRIPTION
1.adding AC_CONFIG_MACRO_DIR([m4]) to configure.in
2.Fix Makefile.am to remove warnings
Reference:https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/libidl/0.8.14-4/libidl_0.8.14-4.debian.tar.xz